### PR TITLE
add log_statement='all' to postgis deployment

### DIFF
--- a/manifests/mosmix/postgis-deployment.yml
+++ b/manifests/mosmix/postgis-deployment.yml
@@ -21,6 +21,7 @@ spec:
       containers:
       - name: postgis
         image: mdillon/postgis:10-alpine
+        command: ["--log_statement='all'"]
         env:
         - name: POSTGRES_USER
           value: mosmix

--- a/manifests/mosmix/postgis-deployment.yml
+++ b/manifests/mosmix/postgis-deployment.yml
@@ -18,10 +18,12 @@ spec:
         app: postgis # has to match .spec.selector.matchLabels
     spec:
       terminationGracePeriodSeconds: 10
+      securityContext:
+        runAsUser: 70
       containers:
       - name: postgis
         image: mdillon/postgis:10-alpine
-        command: ["--log_statement='all'"]
+        command: ["postgres", "--log_statement=all"]
         env:
         - name: POSTGRES_USER
           value: mosmix


### PR DESCRIPTION
Add `log_statements='all'` to the postgis deployment as `command`. This will print all SQL statements issued to the database to logs. 

This should only be temporary but will help to investigate downtimes.