### PR TITLE
Use newer postgres image for crashes-shiny

### DIFF
--- a/manifests/crashes/postgis.yaml
+++ b/manifests/crashes/postgis.yaml
@@ -43,7 +43,7 @@ spec:
       containers:
       - name: postgis
         # image: quay.io/codeformuenster/verkehrsunfall-postgis:master
-        image: quay.io/codeformuenster/verkehrsunfaelle:2019-05-18
+        image: quay.io/codeformuenster/verkehrsunfaelle:2019-06-06
         ports:
         - name: postgres
           containerPort: 5432


### PR DESCRIPTION
Already applied this on the cluster.. Just needed you to see this @webwurst 