### PR TITLE
update traffic to newest version; add fathom tracking code

### DIFF
--- a/manifests/traffics/shiny.yaml
+++ b/manifests/traffics/shiny.yaml
@@ -92,6 +92,14 @@ spec:
         # FIXME
         # resources:
         #   null
+    volumeMounts:
+        - name: renviron-file
+          mountPath: /srv/shiny-server/.Renviron
+          subPath: .Renviron
+      volumes:
+      - name: renviron-file
+        configMap:
+          name: renviron
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -100,6 +108,7 @@ metadata:
   labels:
     app.kubernetes.io/name: shiny
     app.kubernetes.io/component: webserver
+    app.kubernetes.io/part-of: traffics
 data:
   .Renviron: |
     FATHOM_SITEID=UFRTE

--- a/manifests/traffics/shiny.yaml
+++ b/manifests/traffics/shiny.yaml
@@ -86,9 +86,20 @@ spec:
     spec:
       containers:
       - name: shiny
-        image: codeformuenster/traffic-dynamics-shiny:v0.5.1.3
+        image: codeformuenster/traffic-dynamics-shiny:v0.6.0
         ports:
         - containerPort: 3838
         # FIXME
         # resources:
         #   null
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: renviron
+  labels:
+    app.kubernetes.io/name: shiny
+    app.kubernetes.io/component: webserver
+data:
+  .Renviron: |
+    FATHOM_SITEID=UFRTE

--- a/manifests/traffics/shiny.yaml
+++ b/manifests/traffics/shiny.yaml
@@ -92,7 +92,7 @@ spec:
         # FIXME
         # resources:
         #   null
-    volumeMounts:
+        volumeMounts:
         - name: renviron-file
           mountPath: /srv/shiny-server/.Renviron
           subPath: .Renviron


### PR DESCRIPTION
changes:
- update to newest version of traffic-dynamics-shiny (this is not yet released; the base docker image needs a rebuild due to too old packages in the earlier version; I'm testing this locally right now and will write here, when the new version is released)
- adds the fathom tracking code as `.Renviron`, [similar to crashes](https://github.com/codeformuenster/kubernetes-deployment/blob/master/sources/crashes/shiny.yaml#L86-L96) (thanks @ubergesundheit!)

Let me know, if I'm doing something wrong :)