### PR TITLE
Swms busradar gtfs realtime

### DIFF
--- a/sources/swms-busradar-gtfs-realtime/README.md
+++ b/sources/swms-busradar-gtfs-realtime/README.md
@@ -1,0 +1,12 @@
+# swms-busradar-gtfs-realtime Deployment
+
+Deployment of [swms-busradar-gtfs-realtime](https://github.com/codeformuenster/swms-busradar-gtfs-realtime)
+
+```bash
+# build manifests to verify
+kubectl kustomize
+
+# apply to cluster
+kubectl create namespace swms-busradar-gtfs-realtime
+kubectl apply -k .
+```

--- a/sources/swms-busradar-gtfs-realtime/fileserver.yaml
+++ b/sources/swms-busradar-gtfs-realtime/fileserver.yaml
@@ -85,10 +85,16 @@ spec:
         - name: caddyfile
           mountPath: /etc/Caddyfile
           subPath: Caddyfile
+        - name: realtime-feed-volume
+          mountPath: /srv
+          readOnly: true
       volumes:
       - name: caddyfile
         configMap:
           name: caddyfile
+      - name: realtime-feed-volume
+        persistentVolumeClaim:
+          claimName: swms-busradar-gtfs-realtime-volume
 
 ---
 apiVersion: v1

--- a/sources/swms-busradar-gtfs-realtime/fileserver.yaml
+++ b/sources/swms-busradar-gtfs-realtime/fileserver.yaml
@@ -1,0 +1,108 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: swms-busradar-gtfs-realtime-fileserver
+  labels:
+    app.kubernetes.io/name: swms-busradar-gtfs-realtime-fileserver
+    app.kubernetes.io/component: fileserver
+    app.kubernetes.io/part-of: swms-busradar-gtfs-realtime
+spec:
+  ports:
+  - port: 2015
+  selector:
+    app.kubernetes.io/name: swms-busradar-gtfs-realtime-fileserver
+    app.kubernetes.io/component: fileserver
+    app.kubernetes.io/part-of: swms-busradar-gtfs-realtime
+
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: swms-busradar-gtfs-realtime-fileserver
+  labels:
+    app.kubernetes.io/name: swms-busradar-gtfs-realtime-fileserver
+    app.kubernetes.io/component: fileserver
+    app.kubernetes.io/part-of: swms-busradar-gtfs-realtime
+spec:
+  rules:
+  - host: swms-busradar-gtfs-realtime.codeformuenster.org
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: swms-busradar-gtfs-realtime-fileserver
+          servicePort: 2015
+  tls:
+  - hosts:
+    - swms-busradar-gtfs-realtime.codeformuenster.org
+    secretName: swms-busradar-gtfs-realtime-tls
+
+---
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: swms-busradar-gtfs-realtime-tls
+  labels:
+    app.kubernetes.io/name: swms-busradar-gtfs-realtime-fileserver
+    app.kubernetes.io/component: fileserver
+    app.kubernetes.io/part-of: swms-busradar-gtfs-realtime
+spec:
+  secretName: swms-busradar-gtfs-realtime-tls
+  commonName: swms-busradar-gtfs-realtime.codeformuenster.org
+  issuerRef:
+    kind: ClusterIssuer
+    name: letsencrypt
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: swms-busradar-gtfs-realtime-fileserver
+  labels:
+    app.kubernetes.io/name: swms-busradar-gtfs-realtime-fileserver
+    app.kubernetes.io/component: fileserver
+    app.kubernetes.io/part-of: swms-busradar-gtfs-realtime
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: swms-busradar-gtfs-realtime-fileserver
+      app.kubernetes.io/component: fileserver
+      app.kubernetes.io/part-of: swms-busradar-gtfs-realtime
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: swms-busradar-gtfs-realtime-fileserver
+        app.kubernetes.io/component: fileserver
+        app.kubernetes.io/part-of: swms-busradar-gtfs-realtime
+    spec:
+      containers:
+      - name: swms-busradar-gtfs-realtime-fileserver
+        image: abiosoft/caddy:1.0.3-no-stats
+        ports:
+        - containerPort: 2015
+        volumeMounts:
+        - name: caddyfile
+          mountPath: /etc/Caddyfile
+          subPath: Caddyfile
+      volumes:
+      - name: caddyfile
+        configMap:
+          name: caddyfile
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: caddyfile
+  labels:
+    app.kubernetes.io/name: swms-busradar-gtfs-realtime-fileserver
+    app.kubernetes.io/component: fileserver
+    app.kubernetes.io/part-of: swms-busradar-gtfs-realtime
+data:
+  Caddyfile: |
+    0.0.0.0
+    root /srv
+    gzip
+    log stdout
+    errors stdout

--- a/sources/swms-busradar-gtfs-realtime/kustomization.yaml
+++ b/sources/swms-busradar-gtfs-realtime/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: swms-busradar-gtfs-realtime
+commonLabels:
+  app.kubernetes.io/part-of: swms-busradar-gtfs-realtime
+
+resources:
+- ./swms-busradar-gtfs-realtime.yaml
+- ./fileserver.yaml
+
+images:
+- name: quay.io/codeformuenster/swms-busradar-gtfs-realtime
+  newTag: 0.2.0
+- name: quay.io/codeformuenster/swms-busradar-gtfs-realtime-init
+  newTag: 0.2.0
+- name: abiosoft/caddy
+  newTag: 1.0.3-no-stats

--- a/sources/swms-busradar-gtfs-realtime/swms-busradar-gtfs-realtime.yaml
+++ b/sources/swms-busradar-gtfs-realtime/swms-busradar-gtfs-realtime.yaml
@@ -1,3 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: swms-busradar-gtfs-realtime-volume
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5M
+---
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -23,12 +35,26 @@ spec:
       volumes:
       - name: static-feed-volume
         emptyDir: {}
-      - name:
+      - name: realtime-feed-volume
+        persistentVolumeClaim:
+          claimName: swms-busradar-gtfs-realtime-volume
       initContainers:
       - name: swms-busradar-gtfs-realtime-init
+        image: quay.io/codeformuenster/swms-busradar-gtfs-realtime-init:0.2.0
         volumeMounts:
-          - mountPath: /dumps
-            name: static-feed-volume
+        - mountPath: /gtfsfeed
+          name: static-feed-volume
       containers:
       - name: swms-busradar-gtfs-realtime
         image: quay.io/codeformuenster/swms-busradar-gtfs-realtime:0.2.0
+        env:
+        - name: GTFS_FEED_PATH
+          value: /gtfs-static-feed
+        - name: GTFS_REALTIME_FEED_PATH
+          value: /gtfs-realtime-feed/feed
+        volumeMounts:
+        - mountPath: /gtfs-static-feed
+          name: static-feed-volume
+          readOnly: true
+        - mountPath: /gtfs-realtime-feed
+          name: realtime-feed-volume

--- a/sources/swms-busradar-gtfs-realtime/swms-busradar-gtfs-realtime.yaml
+++ b/sources/swms-busradar-gtfs-realtime/swms-busradar-gtfs-realtime.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: swms-busradar-gtfs-realtime
+  labels:
+    app.kubernetes.io/name: swms-busradar-gtfs-realtime
+    app.kubernetes.io/component: translator
+    app.kubernetes.io/part-of: swms-busradar-gtfs-realtime
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: swms-busradar-gtfs-realtime
+      app.kubernetes.io/component: translator
+      app.kubernetes.io/part-of: swms-busradar-gtfs-realtime
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: swms-busradar-gtfs-realtime
+        app.kubernetes.io/component: translator
+        app.kubernetes.io/part-of: swms-busradar-gtfs-realtime
+    spec:
+      volumes:
+      - name: static-feed-volume
+        emptyDir: {}
+      - name:
+      initContainers:
+      - name: swms-busradar-gtfs-realtime-init
+        volumeMounts:
+          - mountPath: /dumps
+            name: static-feed-volume
+      containers:
+      - name: swms-busradar-gtfs-realtime
+        image: quay.io/codeformuenster/swms-busradar-gtfs-realtime:0.2.0


### PR DESCRIPTION
Passt so?

Gibt 2 Pods

- Einmal den translator, der schreibt in ein Persistent Volume eine datei
- Einen Caddy der die Datei rausgibt

- Einen initContainer der den statischen GTFS feed von den Stadtwerken runterlädt und dem translator zur Verfügung stellt