### PR TITLE
Update Meine Stadt Transparent management commands to new syntax

### DIFF
--- a/sources/meine-stadt-transparent/README.md
+++ b/sources/meine-stadt-transparent/README.md
@@ -31,6 +31,6 @@ kubectl -n meine-stadt-transparent create secret docker-registry regcred --docke
 Find your Gemeindeschlüssel
 
 ```
-kubectl -n meine-stadt-transparent exec deployments/meine-stadt-transparent .venv/bin/python manage.py import_outline <gemeindeschlüssel> 1
-kubectl -n meine-stadt-transparent exec deployments/meine-stadt-transparent .venv/bin/python manage.py import_streets <gemeindeschlüssel> 1
+kubectl -n meine-stadt-transparent exec deployments/meine-stadt-transparent .venv/bin/python manage.py import_outline 1 --ags <gemeindeschlüssel>
+kubectl -n meine-stadt-transparent exec deployments/meine-stadt-transparent .venv/bin/python manage.py import_streets 1 --ags <gemeindeschlüssel>
 ```


### PR DESCRIPTION
The ags should be stored with the body already, which is why this became an optional flag. This change will is part of the v0.2.0 image of Meine Stadt Transparent (once that finishes building).